### PR TITLE
Configure transmitter build using LoRa_APRS_Tracker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@
 *.exe
 *.out
 *.app
+
+# PlatformIO
+.pio/
+.vscode/

--- a/LoRa_APRS_Tracker/platformio.ini
+++ b/LoRa_APRS_Tracker/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = ttgo-t-beam-v1_2
+default_envs = heltec_wireless_tracker
 
 extra_configs =
 	common_settings.ini

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# tesina-firmware
+# Tesina Firmware
 
+Repositorio que contiene el desarrollo del firmware para el sistema de rastreo de ganado basado en placas Heltec.
+
+## Estructura del proyecto
+
+- **docs/** – Documentación general del proyecto.
+- **data/** – Datos de prueba y archivos de configuración.
+- **images/** – Recursos gráficos y diagramas.
+- **extra/** – Material de referencia adicional.
+- **tools/** – Scripts y utilidades de apoyo.
+- **settings/** – Plantillas y ajustes de configuración.
+- **firmware/** – Código fuente del firmware.
+  - **transmitter/** – Proyecto PlatformIO para el transmisor (Heltec Wireless Tracker).
+  - **receiver/** – Proyecto PlatformIO para el receptor (Heltec WiFi LoRa 32 V3/V3.2).
+
+Cada subproyecto dentro de `firmware/` puede compilarse y cargarse de forma independiente sobre la placa correspondiente.

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,3 @@
+# Datos
+
+Directorio para almacenar archivos de datos, registros de pruebas y configuraciones.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# Documentación
+
+Aquí se incluirán guías de uso, notas de diseño y referencias técnicas.

--- a/extra/README.md
+++ b/extra/README.md
@@ -1,0 +1,3 @@
+# Extra
+
+Material de referencia y recursos complementarios.

--- a/firmware/receiver/README.md
+++ b/firmware/receiver/README.md
@@ -1,0 +1,3 @@
+# Firmware del Receptor
+
+Proyecto basado en la placa **Heltec WiFi LoRa 32 V3/V3.2**. Aquí se implementará la lógica de recepción LoRa y visualización.

--- a/firmware/receiver/platformio.ini
+++ b/firmware/receiver/platformio.ini
@@ -1,0 +1,5 @@
+[env:heltec_wifi_lora_32_V3]
+platform = espressif32
+board = heltec_wifi_lora_32_V3
+framework = arduino
+monitor_speed = 115200

--- a/firmware/receiver/src/main.cpp
+++ b/firmware/receiver/src/main.cpp
@@ -1,0 +1,9 @@
+#include <Arduino.h>
+
+void setup() {
+    // Inicialización de hardware del receptor
+}
+
+void loop() {
+    // Lógica principal del receptor
+}

--- a/firmware/transmitter/README.md
+++ b/firmware/transmitter/README.md
@@ -1,0 +1,23 @@
+# Firmware del Transmisor
+
+El firmware del collar transmisor se construye a partir del proyecto
+[LoRa_APRS_Tracker](../../LoRa_APRS_Tracker). Ese repositorio ya incluye
+soporte completo para la placa **Heltec Wireless Tracker** e incorpora las
+rutinas de GPS, LoRa y gestión de energía necesarias para nuestro sistema.
+
+## Compilación
+
+1. Instalar [PlatformIO](https://platformio.org/install) en el entorno de
+   desarrollo.
+2. Desde la raíz del proyecto ejecutar:
+
+   ```bash
+   cd LoRa_APRS_Tracker
+   pio run -e heltec_wireless_tracker
+   ```
+
+3. El binario generado en `.pio/build/heltec_wireless_tracker/` puede
+   cargarse a la placa mediante `pio run -e heltec_wireless_tracker -t upload`.
+
+El archivo `data/tracker_conf.json` dentro de `LoRa_APRS_Tracker` contiene la
+configuración del transmisor (frecuencias, identificador, etc.).

--- a/images/README.md
+++ b/images/README.md
@@ -1,0 +1,3 @@
+# Imágenes
+
+Contiene diagramas, fotografías y otros recursos gráficos relacionados con el proyecto.

--- a/settings/README.md
+++ b/settings/README.md
@@ -1,0 +1,3 @@
+# Configuración
+
+Plantillas y archivos de configuración comunes para el proyecto.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,3 @@
+# Herramientas
+
+Scripts y utilidades para automatizar tareas de desarrollo y despliegue.


### PR DESCRIPTION
## Summary
- set LoRa_APRS_Tracker default environment to the Heltec Wireless Tracker
- point transmitter firmware directory to LoRa_APRS_Tracker and document build steps

## Testing
- `pio --version`
- `pio run -e heltec_wireless_tracker` *(fails: HTTPClientError while installing espressif32)*

------
https://chatgpt.com/codex/tasks/task_e_689b45bdeb4c832e885dec93e023f8e1